### PR TITLE
build failing due to extra bracket

### DIFF
--- a/src/main/java/com/redhat/idaas/connect/hl7/CamelConfiguration.java
+++ b/src/main/java/com/redhat/idaas/connect/hl7/CamelConfiguration.java
@@ -120,7 +120,7 @@ public class CamelConfiguration extends RouteBuilder {
      *
      */
 	  // ADT
-	  from("file:src/data-in/hl7v2/adt?delete=true?noop=true"))
+	  from("file:src/data-in/hl7v2/adt?delete=true?noop=true")
           .routeId("hl7Admissions")
           .convertBodyTo(String.class)
           // set Auditing Properties


### PR DESCRIPTION
Local builds failing due to extra bracket at following line:
[CamelConfiguration.java](https://github.com/RedHat-Healthcare/OSD-iDAAS-Connect-HL7/blob/6b6b1e843da9c7dd4c31a69904803b716911eafd/src/main/java/com/redhat/idaas/connect/hl7/CamelConfiguration.java#L123)

Fixed by removing the extra bracket.