### PR TITLE
Add Windows support to platform-scripts

### DIFF
--- a/platform-scripts/start-solution.bat
+++ b/platform-scripts/start-solution.bat
@@ -1,0 +1,6 @@
+cd windows
+echo "Starting Kafka in background"
+cmd.exe /C start_kafka.bat
+cd ../..
+cd target
+java -jar idaas-connect-hl7.jar

--- a/platform-scripts/stop-solution.bat
+++ b/platform-scripts/stop-solution.bat
@@ -1,0 +1,9 @@
+echo "Stopping Kafka and Zookeeper running in background"
+cd windows
+cmd.exe /C stop_kafka.bat
+echo "Stopping iDaas - Connect HL7"
+cd ../..
+cd target
+set /p hl7pid=<bin\shutdown.pid
+Taskkill /PID %hl7pid% /F
+

--- a/platform-scripts/windows/kafkacmd_topics_create-iDAAS-HL7.bat
+++ b/platform-scripts/windows/kafkacmd_topics_create-iDAAS-HL7.bat
@@ -1,0 +1,25 @@
+cd C:\RedHatTech\kafka_2.12-2.6.0
+
+:: Operational Topics for Platform
+call .\bin\windows\kafka-topics.bat --create --bootstrap-server localhost:9092 --replication-factor 1^
+ --partitions 1 --topic opsmgmt_platformtransactions
+:: HL7
+:: Inbound to iDAAS Platform by Message Trigger
+:: Facility: MCTN
+:: Application: MMS
+call .\bin\windows\kafka-topics.bat --create --bootstrap-server localhost:9092 --replication-factor 1^
+ --partitions 1 --topic mctn_mms_adt
+
+:: HL7
+:: Facility By Application by Message Trigger
+:: Facility: MCTN
+:: Application: MMS
+
+:: HL7
+:: Enterprise By Application by Message Trigger
+:: Facility: MCTN
+:: Application: MMS
+
+:: HL7
+:: Enterprise by Message Trigger
+:: Application: MMS

--- a/platform-scripts/windows/kafkacmd_topics_delete-iDAAS-HL7.bat
+++ b/platform-scripts/windows/kafkacmd_topics_delete-iDAAS-HL7.bat
@@ -1,0 +1,23 @@
+cd C:\RedHatTech\kafka_2.12-2.6.0
+
+:: Operational Topics for Platform
+call .\bin\windows\kafka-topics.bat --delete --bootstrap-server localhost:9092 --topic opsmgmt_platformtransactions
+:: HL7
+:: Inbound to iDAAS Platform by Message Trigger
+:: Facility: MCTN
+:: Application: MMS
+call .\bin\windows\kafka-topics.bat --delete --bootstrap-server localhost:9092 --topic mctn_mms_adt
+
+:: HL7
+:: Facility By Application by Message Trigger
+:: Facility: MCTN
+:: Application: MMS
+
+:: HL7
+:: Enterprise By Application by Message Trigger
+:: Facility: MCTN
+:: Application: MMS
+
+:: HL7
+:: Enterprise by Message Trigger
+:: Application: MMS

--- a/platform-scripts/windows/kafkacmd_topics_list.bat
+++ b/platform-scripts/windows/kafkacmd_topics_list.bat
@@ -1,0 +1,4 @@
+cd C:\RedHatTech\kafka_2.12-2.6.0
+
+call .\bin\windows\kafka-topics.bat --list --bootstrap-server localhost:9092
+

--- a/platform-scripts/windows/start_kafka.bat
+++ b/platform-scripts/windows/start_kafka.bat
@@ -1,0 +1,3 @@
+cd c:\RedHatTech\kafka_2.12-2.6.0\
+start /B .\bin\windows\zookeeper-server-start.bat .\config\zookeeper.properties
+start /B .\bin\windows\kafka-server-start.bat .\config\server.properties

--- a/platform-scripts/windows/stop_kafka.bat
+++ b/platform-scripts/windows/stop_kafka.bat
@@ -1,0 +1,6 @@
+cd C:\RedHatTech\kafka_2.12-2.6.0
+echo "Stop Kafka...."
+start /B .\bin\windows\kafka-server-stop.bat config\server.properties
+echo "Stop Zookeeper...."
+start /B .\bin\windows\zookeeper-server-stop.bat config\zookeeper.properties
+


### PR DESCRIPTION
1. Add start-solution.bat and stop-solution.bat for Windows support.

2. Add a windows folder containing bat scripts to start/stop kafka and to create/delete/list topics.