### PR TITLE
Update kafkaTopicUri

### DIFF
--- a/src/main/java/com/redhat/idaas/connect/hl7/CamelConfiguration.java
+++ b/src/main/java/com/redhat/idaas/connect/hl7/CamelConfiguration.java
@@ -161,7 +161,7 @@ public class CamelConfiguration extends RouteBuilder {
     /*
      *    HL7v2 ADT
      */
-    from("kafka:localhost:9092?topic= mctn_mms_adt&brokers=localhost:9092")
+    from(getKafkaTopicUri("mctn_mms_adt"))
             .routeId("ADT-MiddleTier")
             // Auditing
             .setProperty("processingtype").constant("data")


### PR DESCRIPTION
Changed the kafka topic uri to a variable instead of hardcoded. This fixes a bug where the data wasn't moving to the `mms_adt` topic.